### PR TITLE
Add client hitstop packet

### DIFF
--- a/src/main/java/com/fredtad/macemod/ChannelHandler.java
+++ b/src/main/java/com/fredtad/macemod/ChannelHandler.java
@@ -1,0 +1,17 @@
+package com.fredtad.macemod;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+
+@EventBusSubscriber(modid = MaceMod.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public class ChannelHandler {
+    private static final String VERSION = "1";
+
+    @SubscribeEvent
+    public static void register(RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar(VERSION);
+        registrar.playToClient(StartHitStopPacket.TYPE, StartHitStopPacket.STREAM_CODEC, StartHitStopPacket::handle);
+    }
+}

--- a/src/main/java/com/fredtad/macemod/HitStopHandler.java
+++ b/src/main/java/com/fredtad/macemod/HitStopHandler.java
@@ -3,6 +3,11 @@ package com.fredtad.macemod;
 public class HitStopHandler {
     private static boolean isFrozen = false;
 
+    public static void startFreeze(int duration) {
+        isFrozen = true;
+        System.out.println("Client hitstop started for " + duration + " ticks");
+    }
+
     public static void clearFreeze() {
         isFrozen = false;
         System.out.println("Hitstop cleared — server unfreezing world.");

--- a/src/main/java/com/fredtad/macemod/MaceImpactHandler.java
+++ b/src/main/java/com/fredtad/macemod/MaceImpactHandler.java
@@ -9,6 +9,10 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.minecraft.world.item.MaceItem;
 import net.neoforged.neoforge.event.entity.living.LivingDamageEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.minecraft.server.level.ServerPlayer;
+
+import com.fredtad.macemod.StartHitStopPacket;
 
 
 @EventBusSubscriber(modid = "maceimpactframes")   // default bus = GAME
@@ -26,6 +30,7 @@ public final class MaceImpactHandler {
         if (!data.getBoolean("macemod.pendingSlam")) return;
 
         // --- It *was* our mace smash ---
+        PacketDistributor.sendToPlayer((ServerPlayer) player, new StartHitStopPacket(6));
         data.remove("macemod.pendingSlam");          // consume the flag
 
         float damage = event.getNewDamage();         // final damage

--- a/src/main/java/com/fredtad/macemod/MaceMod.java
+++ b/src/main/java/com/fredtad/macemod/MaceMod.java
@@ -53,6 +53,7 @@ public class MaceMod    {
         // Some common setup code
         LOGGER.info("HELLO FROM COMMON SETUP");
 
+
         if (Config.LOG_DIRT_BLOCK.getAsBoolean()) {
             LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
         }

--- a/src/main/java/com/fredtad/macemod/StartHitStopPacket.java
+++ b/src/main/java/com/fredtad/macemod/StartHitStopPacket.java
@@ -1,0 +1,22 @@
+package com.fredtad.macemod;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+public record StartHitStopPacket(int duration) implements CustomPacketPayload {
+    public static final Type<StartHitStopPacket> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(MaceMod.MOD_ID, "start_hit_stop"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, StartHitStopPacket> STREAM_CODEC =
+            StreamCodec.composite(ByteBufCodecs.VAR_INT, StartHitStopPacket::duration, StartHitStopPacket::new);
+
+    @Override
+    public Type<StartHitStopPacket> type() {
+        return TYPE;
+    }
+
+    public static void handle(StartHitStopPacket payload, net.neoforged.neoforge.network.handling.IPayloadContext ctx) {
+        ctx.enqueueWork(() -> HitStopHandler.startFreeze(payload.duration()));
+    }
+}


### PR DESCRIPTION
## Summary
- add network payload registration through `ChannelHandler`
- implement a `StartHitStopPacket` custom payload
- send `StartHitStopPacket` after mace slam damage
- handle client freeze via `HitStopHandler`

## Testing
- `./gradlew classes`

------
https://chatgpt.com/codex/tasks/task_e_6869b02ce524832ea5505cf80aaac50a